### PR TITLE
Workaround for unsupported methods in CONNX JDBC Driver

### DIFF
--- a/src/main/java/org/teiid/translator/adabas/AdabasExecutionFactory.java
+++ b/src/main/java/org/teiid/translator/adabas/AdabasExecutionFactory.java
@@ -22,6 +22,9 @@
 
 package org.teiid.translator.adabas;
 
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -199,5 +202,25 @@ public class AdabasExecutionFactory extends JDBCExecutionFactory {
         supportedFunctions.add(SourceSystemFunctions.COALESCE);
         
         return supportedFunctions;
-    }    
+    }
+
+    /*
+    * Since CONNX does not support some methods of JDBC API, we need to wrap the
+    * object to provide some alternatives so the query can run without problems.
+    *
+    * The problem is on get methods that takes a Calendar and all set methods.
+    * They all throws exceptions saying that the method is not supported.
+    *
+    * Note that these wrappers only solves the get methods.
+    */
+
+    @Override
+    public Object retrieveValue(ResultSet results, int columnIndex, Class<?> expectedType) throws SQLException {
+        return super.retrieveValue(new ConnxResultSetWrapper(results), columnIndex, expectedType);
+    }
+
+    @Override
+    public Object retrieveValue(CallableStatement results, int parameterIndex, Class<?> expectedType) throws SQLException {
+        return super.retrieveValue(new ConnxCallableStatementWrapper(results), parameterIndex, expectedType);
+    }
 }

--- a/src/main/java/org/teiid/translator/adabas/CalendarHelper.java
+++ b/src/main/java/org/teiid/translator/adabas/CalendarHelper.java
@@ -1,0 +1,36 @@
+package org.teiid.translator.adabas;
+
+import org.teiid.core.util.TimestampWithTimezone;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+public class CalendarHelper {
+
+  public static Time adjustTime(Calendar cal, Time value) {
+    if (value != null && cal != null) {
+      value = TimestampWithTimezone.createTime(value,
+          Calendar.getInstance().getTimeZone(), cal);
+    }
+    return value;
+  }
+
+  public static Date adjustDate(Calendar cal, Date value) {
+    if (value != null && cal != null) {
+      value = TimestampWithTimezone.createDate(value,
+          Calendar.getInstance().getTimeZone(), cal);
+    }
+    return value;
+  }
+
+  public static Timestamp adjustTimestamp(Calendar cal, Timestamp value) {
+    if (value != null && cal != null) {
+      value = TimestampWithTimezone.createTimestamp(value,
+          Calendar.getInstance().getTimeZone(), cal);
+    }
+    return value;
+  }
+
+}

--- a/src/main/java/org/teiid/translator/adabas/ConnxCallableStatementWrapper.java
+++ b/src/main/java/org/teiid/translator/adabas/ConnxCallableStatementWrapper.java
@@ -16,6 +16,36 @@ public class ConnxCallableStatementWrapper implements CallableStatement {
     this.realStatement = realStatement;
   }
 
+  //CONNX does not support this method
+  public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
+    return realStatement.getDate(parameterIndex);
+  }
+
+  //CONNX does not support this method
+  public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
+    return realStatement.getTime(parameterIndex);
+  }
+
+  //CONNX does not support this method
+  public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
+    return realStatement.getTimestamp(parameterIndex);
+  }
+
+  //CONNX does not support this method
+  public Date getDate(String parameterName, Calendar cal) throws SQLException {
+    return realStatement.getDate(parameterName);
+  }
+
+  //CONNX does not support this method
+  public Time getTime(String parameterName, Calendar cal) throws SQLException {
+    return realStatement.getTime(parameterName);
+  }
+
+  //CONNX does not support this method
+  public Timestamp getTimestamp(String parameterName, Calendar cal) throws SQLException {
+    return realStatement.getTimestamp(parameterName);
+  }
+
   public void registerOutParameter(int parameterIndex, int sqlType) throws SQLException {
     realStatement.registerOutParameter(parameterIndex, sqlType);
   }
@@ -106,21 +136,6 @@ public class ConnxCallableStatementWrapper implements CallableStatement {
 
   public Array getArray(int parameterIndex) throws SQLException {
     return realStatement.getArray(parameterIndex);
-  }
-
-  //CONNX does not support this method
-  public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
-    return realStatement.getDate(parameterIndex);
-  }
-
-  //CONNX does not support this method
-  public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
-    return realStatement.getTime(parameterIndex);
-  }
-
-  //CONNX does not support this method
-  public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
-    return realStatement.getTimestamp(parameterIndex);
   }
 
   public void registerOutParameter(int parameterIndex, int sqlType, String typeName) throws SQLException {
@@ -317,21 +332,6 @@ public class ConnxCallableStatementWrapper implements CallableStatement {
 
   public Array getArray(String parameterName) throws SQLException {
     return realStatement.getArray(parameterName);
-  }
-
-  //CONNX does not support this method
-  public Date getDate(String parameterName, Calendar cal) throws SQLException {
-    return realStatement.getDate(parameterName);
-  }
-
-  //CONNX does not support this method
-  public Time getTime(String parameterName, Calendar cal) throws SQLException {
-    return realStatement.getTime(parameterName);
-  }
-
-  //CONNX does not support this method
-  public Timestamp getTimestamp(String parameterName, Calendar cal) throws SQLException {
-    return realStatement.getTimestamp(parameterName);
   }
 
   public URL getURL(String parameterName) throws SQLException {

--- a/src/main/java/org/teiid/translator/adabas/ConnxCallableStatementWrapper.java
+++ b/src/main/java/org/teiid/translator/adabas/ConnxCallableStatementWrapper.java
@@ -16,6 +16,8 @@ public class ConnxCallableStatementWrapper implements CallableStatement {
     this.realStatement = realStatement;
   }
 
+  //TODO use the calendar instance after delegating the method to implement the expected behaviour
+
   //CONNX does not support this method
   public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
     return realStatement.getDate(parameterIndex);

--- a/src/main/java/org/teiid/translator/adabas/ConnxCallableStatementWrapper.java
+++ b/src/main/java/org/teiid/translator/adabas/ConnxCallableStatementWrapper.java
@@ -1,0 +1,872 @@
+package org.teiid.translator.adabas;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
+import java.util.Calendar;
+import java.util.Map;
+
+public class ConnxCallableStatementWrapper implements CallableStatement {
+
+  private final CallableStatement realStatement;
+
+  public ConnxCallableStatementWrapper(CallableStatement realStatement) {
+    this.realStatement = realStatement;
+  }
+
+  public void registerOutParameter(int parameterIndex, int sqlType) throws SQLException {
+    realStatement.registerOutParameter(parameterIndex, sqlType);
+  }
+
+  public void registerOutParameter(int parameterIndex, int sqlType, int scale) throws SQLException {
+    realStatement.registerOutParameter(parameterIndex, sqlType, scale);
+  }
+
+  public boolean wasNull() throws SQLException {
+    return realStatement.wasNull();
+  }
+
+  public String getString(int parameterIndex) throws SQLException {
+    return realStatement.getString(parameterIndex);
+  }
+
+  public boolean getBoolean(int parameterIndex) throws SQLException {
+    return realStatement.getBoolean(parameterIndex);
+  }
+
+  public byte getByte(int parameterIndex) throws SQLException {
+    return realStatement.getByte(parameterIndex);
+  }
+
+  public short getShort(int parameterIndex) throws SQLException {
+    return realStatement.getShort(parameterIndex);
+  }
+
+  public int getInt(int parameterIndex) throws SQLException {
+    return realStatement.getInt(parameterIndex);
+  }
+
+  public long getLong(int parameterIndex) throws SQLException {
+    return realStatement.getLong(parameterIndex);
+  }
+
+  public float getFloat(int parameterIndex) throws SQLException {
+    return realStatement.getFloat(parameterIndex);
+  }
+
+  public double getDouble(int parameterIndex) throws SQLException {
+    return realStatement.getDouble(parameterIndex);
+  }
+
+  public BigDecimal getBigDecimal(int parameterIndex, int scale) throws SQLException {
+    return realStatement.getBigDecimal(parameterIndex, scale);
+  }
+
+  public byte[] getBytes(int parameterIndex) throws SQLException {
+    return realStatement.getBytes(parameterIndex);
+  }
+
+  public Date getDate(int parameterIndex) throws SQLException {
+    return realStatement.getDate(parameterIndex);
+  }
+
+  public Time getTime(int parameterIndex) throws SQLException {
+    return realStatement.getTime(parameterIndex);
+  }
+
+  public Timestamp getTimestamp(int parameterIndex) throws SQLException {
+    return realStatement.getTimestamp(parameterIndex);
+  }
+
+  public Object getObject(int parameterIndex) throws SQLException {
+    return realStatement.getObject(parameterIndex);
+  }
+
+  public BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
+    return realStatement.getBigDecimal(parameterIndex);
+  }
+
+  public Object getObject(int parameterIndex, Map<String, Class<?>> map) throws SQLException {
+    return realStatement.getObject(parameterIndex, map);
+  }
+
+  public Ref getRef(int parameterIndex) throws SQLException {
+    return realStatement.getRef(parameterIndex);
+  }
+
+  public Blob getBlob(int parameterIndex) throws SQLException {
+    return realStatement.getBlob(parameterIndex);
+  }
+
+  public Clob getClob(int parameterIndex) throws SQLException {
+    return realStatement.getClob(parameterIndex);
+  }
+
+  public Array getArray(int parameterIndex) throws SQLException {
+    return realStatement.getArray(parameterIndex);
+  }
+
+  //CONNX does not support this method
+  public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
+    return realStatement.getDate(parameterIndex);
+  }
+
+  //CONNX does not support this method
+  public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
+    return realStatement.getTime(parameterIndex);
+  }
+
+  //CONNX does not support this method
+  public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
+    return realStatement.getTimestamp(parameterIndex);
+  }
+
+  public void registerOutParameter(int parameterIndex, int sqlType, String typeName) throws SQLException {
+    realStatement.registerOutParameter(parameterIndex, sqlType, typeName);
+  }
+
+  public void registerOutParameter(String parameterName, int sqlType) throws SQLException {
+    realStatement.registerOutParameter(parameterName, sqlType);
+  }
+
+  public void registerOutParameter(String parameterName, int sqlType, int scale) throws SQLException {
+    realStatement.registerOutParameter(parameterName, sqlType, scale);
+  }
+
+  public void registerOutParameter(String parameterName, int sqlType, String typeName) throws SQLException {
+    realStatement.registerOutParameter(parameterName, sqlType, typeName);
+  }
+
+  public URL getURL(int parameterIndex) throws SQLException {
+    return realStatement.getURL(parameterIndex);
+  }
+
+  public void setURL(String parameterName, URL val) throws SQLException {
+    realStatement.setURL(parameterName, val);
+  }
+
+  public void setNull(String parameterName, int sqlType) throws SQLException {
+    realStatement.setNull(parameterName, sqlType);
+  }
+
+  public void setBoolean(String parameterName, boolean x) throws SQLException {
+    realStatement.setBoolean(parameterName, x);
+  }
+
+  public void setByte(String parameterName, byte x) throws SQLException {
+    realStatement.setByte(parameterName, x);
+  }
+
+  public void setShort(String parameterName, short x) throws SQLException {
+    realStatement.setShort(parameterName, x);
+  }
+
+  public void setInt(String parameterName, int x) throws SQLException {
+    realStatement.setInt(parameterName, x);
+  }
+
+  public void setLong(String parameterName, long x) throws SQLException {
+    realStatement.setLong(parameterName, x);
+  }
+
+  public void setFloat(String parameterName, float x) throws SQLException {
+    realStatement.setFloat(parameterName, x);
+  }
+
+  public void setDouble(String parameterName, double x) throws SQLException {
+    realStatement.setDouble(parameterName, x);
+  }
+
+  public void setBigDecimal(String parameterName, BigDecimal x) throws SQLException {
+    realStatement.setBigDecimal(parameterName, x);
+  }
+
+  public void setString(String parameterName, String x) throws SQLException {
+    realStatement.setString(parameterName, x);
+  }
+
+  public void setBytes(String parameterName, byte[] x) throws SQLException {
+    realStatement.setBytes(parameterName, x);
+  }
+
+  public void setDate(String parameterName, Date x) throws SQLException {
+    realStatement.setDate(parameterName, x);
+  }
+
+  public void setTime(String parameterName, Time x) throws SQLException {
+    realStatement.setTime(parameterName, x);
+  }
+
+  public void setTimestamp(String parameterName, Timestamp x) throws SQLException {
+    realStatement.setTimestamp(parameterName, x);
+  }
+
+  public void setAsciiStream(String parameterName, InputStream x, int length) throws SQLException {
+    realStatement.setAsciiStream(parameterName, x, length);
+  }
+
+  public void setBinaryStream(String parameterName, InputStream x, int length) throws SQLException {
+    realStatement.setBinaryStream(parameterName, x, length);
+  }
+
+  public void setObject(String parameterName, Object x, int targetSqlType, int scale) throws SQLException {
+    realStatement.setObject(parameterName, x, targetSqlType, scale);
+  }
+
+  public void setObject(String parameterName, Object x, int targetSqlType) throws SQLException {
+    realStatement.setObject(parameterName, x, targetSqlType);
+  }
+
+  public void setObject(String parameterName, Object x) throws SQLException {
+    realStatement.setObject(parameterName, x);
+  }
+
+  public void setCharacterStream(String parameterName, Reader reader, int length) throws SQLException {
+    realStatement.setCharacterStream(parameterName, reader, length);
+  }
+
+  public void setDate(String parameterName, Date x, Calendar cal) throws SQLException {
+    realStatement.setDate(parameterName, x, cal);
+  }
+
+  public void setTime(String parameterName, Time x, Calendar cal) throws SQLException {
+    realStatement.setTime(parameterName, x, cal);
+  }
+
+  public void setTimestamp(String parameterName, Timestamp x, Calendar cal) throws SQLException {
+    realStatement.setTimestamp(parameterName, x, cal);
+  }
+
+  public void setNull(String parameterName, int sqlType, String typeName) throws SQLException {
+    realStatement.setNull(parameterName, sqlType, typeName);
+  }
+
+  public String getString(String parameterName) throws SQLException {
+    return realStatement.getString(parameterName);
+  }
+
+  public boolean getBoolean(String parameterName) throws SQLException {
+    return realStatement.getBoolean(parameterName);
+  }
+
+  public byte getByte(String parameterName) throws SQLException {
+    return realStatement.getByte(parameterName);
+  }
+
+  public short getShort(String parameterName) throws SQLException {
+    return realStatement.getShort(parameterName);
+  }
+
+  public int getInt(String parameterName) throws SQLException {
+    return realStatement.getInt(parameterName);
+  }
+
+  public long getLong(String parameterName) throws SQLException {
+    return realStatement.getLong(parameterName);
+  }
+
+  public float getFloat(String parameterName) throws SQLException {
+    return realStatement.getFloat(parameterName);
+  }
+
+  public double getDouble(String parameterName) throws SQLException {
+    return realStatement.getDouble(parameterName);
+  }
+
+  public byte[] getBytes(String parameterName) throws SQLException {
+    return realStatement.getBytes(parameterName);
+  }
+
+  public Date getDate(String parameterName) throws SQLException {
+    return realStatement.getDate(parameterName);
+  }
+
+  public Time getTime(String parameterName) throws SQLException {
+    return realStatement.getTime(parameterName);
+  }
+
+  public Timestamp getTimestamp(String parameterName) throws SQLException {
+    return realStatement.getTimestamp(parameterName);
+  }
+
+  public Object getObject(String parameterName) throws SQLException {
+    return realStatement.getObject(parameterName);
+  }
+
+  public BigDecimal getBigDecimal(String parameterName) throws SQLException {
+    return realStatement.getBigDecimal(parameterName);
+  }
+
+  public Object getObject(String parameterName, Map<String, Class<?>> map) throws SQLException {
+    return realStatement.getObject(parameterName, map);
+  }
+
+  public Ref getRef(String parameterName) throws SQLException {
+    return realStatement.getRef(parameterName);
+  }
+
+  public Blob getBlob(String parameterName) throws SQLException {
+    return realStatement.getBlob(parameterName);
+  }
+
+  public Clob getClob(String parameterName) throws SQLException {
+    return realStatement.getClob(parameterName);
+  }
+
+  public Array getArray(String parameterName) throws SQLException {
+    return realStatement.getArray(parameterName);
+  }
+
+  //CONNX does not support this method
+  public Date getDate(String parameterName, Calendar cal) throws SQLException {
+    return realStatement.getDate(parameterName);
+  }
+
+  //CONNX does not support this method
+  public Time getTime(String parameterName, Calendar cal) throws SQLException {
+    return realStatement.getTime(parameterName);
+  }
+
+  //CONNX does not support this method
+  public Timestamp getTimestamp(String parameterName, Calendar cal) throws SQLException {
+    return realStatement.getTimestamp(parameterName);
+  }
+
+  public URL getURL(String parameterName) throws SQLException {
+    return realStatement.getURL(parameterName);
+  }
+
+  public RowId getRowId(int parameterIndex) throws SQLException {
+    return realStatement.getRowId(parameterIndex);
+  }
+
+  public RowId getRowId(String parameterName) throws SQLException {
+    return realStatement.getRowId(parameterName);
+  }
+
+  public void setRowId(String parameterName, RowId x) throws SQLException {
+    realStatement.setRowId(parameterName, x);
+  }
+
+  public void setNString(String parameterName, String value) throws SQLException {
+    realStatement.setNString(parameterName, value);
+  }
+
+  public void setNCharacterStream(String parameterName, Reader value, long length) throws SQLException {
+    realStatement.setNCharacterStream(parameterName, value, length);
+  }
+
+  public void setNClob(String parameterName, NClob value) throws SQLException {
+    realStatement.setNClob(parameterName, value);
+  }
+
+  public void setClob(String parameterName, Reader reader, long length) throws SQLException {
+    realStatement.setClob(parameterName, reader, length);
+  }
+
+  public void setBlob(String parameterName, InputStream inputStream, long length) throws SQLException {
+    realStatement.setBlob(parameterName, inputStream, length);
+  }
+
+  public void setNClob(String parameterName, Reader reader, long length) throws SQLException {
+    realStatement.setNClob(parameterName, reader, length);
+  }
+
+  public NClob getNClob(int parameterIndex) throws SQLException {
+    return realStatement.getNClob(parameterIndex);
+  }
+
+  public NClob getNClob(String parameterName) throws SQLException {
+    return realStatement.getNClob(parameterName);
+  }
+
+  public void setSQLXML(String parameterName, SQLXML xmlObject) throws SQLException {
+    realStatement.setSQLXML(parameterName, xmlObject);
+  }
+
+  public SQLXML getSQLXML(int parameterIndex) throws SQLException {
+    return realStatement.getSQLXML(parameterIndex);
+  }
+
+  public SQLXML getSQLXML(String parameterName) throws SQLException {
+    return realStatement.getSQLXML(parameterName);
+  }
+
+  public String getNString(int parameterIndex) throws SQLException {
+    return realStatement.getNString(parameterIndex);
+  }
+
+  public String getNString(String parameterName) throws SQLException {
+    return realStatement.getNString(parameterName);
+  }
+
+  public Reader getNCharacterStream(int parameterIndex) throws SQLException {
+    return realStatement.getNCharacterStream(parameterIndex);
+  }
+
+  public Reader getNCharacterStream(String parameterName) throws SQLException {
+    return realStatement.getNCharacterStream(parameterName);
+  }
+
+  public Reader getCharacterStream(int parameterIndex) throws SQLException {
+    return realStatement.getCharacterStream(parameterIndex);
+  }
+
+  public Reader getCharacterStream(String parameterName) throws SQLException {
+    return realStatement.getCharacterStream(parameterName);
+  }
+
+  public void setBlob(String parameterName, Blob x) throws SQLException {
+    realStatement.setBlob(parameterName, x);
+  }
+
+  public void setClob(String parameterName, Clob x) throws SQLException {
+    realStatement.setClob(parameterName, x);
+  }
+
+  public void setAsciiStream(String parameterName, InputStream x, long length) throws SQLException {
+    realStatement.setAsciiStream(parameterName, x, length);
+  }
+
+  public void setBinaryStream(String parameterName, InputStream x, long length) throws SQLException {
+    realStatement.setBinaryStream(parameterName, x, length);
+  }
+
+  public void setCharacterStream(String parameterName, Reader reader, long length) throws SQLException {
+    realStatement.setCharacterStream(parameterName, reader, length);
+  }
+
+  public void setAsciiStream(String parameterName, InputStream x) throws SQLException {
+    realStatement.setAsciiStream(parameterName, x);
+  }
+
+  public void setBinaryStream(String parameterName, InputStream x) throws SQLException {
+    realStatement.setBinaryStream(parameterName, x);
+  }
+
+  public void setCharacterStream(String parameterName, Reader reader) throws SQLException {
+    realStatement.setCharacterStream(parameterName, reader);
+  }
+
+  public void setNCharacterStream(String parameterName, Reader value) throws SQLException {
+    realStatement.setNCharacterStream(parameterName, value);
+  }
+
+  public void setClob(String parameterName, Reader reader) throws SQLException {
+    realStatement.setClob(parameterName, reader);
+  }
+
+  public void setBlob(String parameterName, InputStream inputStream) throws SQLException {
+    realStatement.setBlob(parameterName, inputStream);
+  }
+
+  public void setNClob(String parameterName, Reader reader) throws SQLException {
+    realStatement.setNClob(parameterName, reader);
+  }
+
+  public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
+    return realStatement.getObject(parameterIndex, type);
+  }
+
+  public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
+    return realStatement.getObject(parameterName, type);
+  }
+
+  public ResultSet executeQuery() throws SQLException {
+    return realStatement.executeQuery();
+  }
+
+  public int executeUpdate() throws SQLException {
+    return realStatement.executeUpdate();
+  }
+
+  public void setNull(int parameterIndex, int sqlType) throws SQLException {
+    realStatement.setNull(parameterIndex, sqlType);
+  }
+
+  public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+    realStatement.setBoolean(parameterIndex, x);
+  }
+
+  public void setByte(int parameterIndex, byte x) throws SQLException {
+    realStatement.setByte(parameterIndex, x);
+  }
+
+  public void setShort(int parameterIndex, short x) throws SQLException {
+    realStatement.setShort(parameterIndex, x);
+  }
+
+  public void setInt(int parameterIndex, int x) throws SQLException {
+    realStatement.setInt(parameterIndex, x);
+  }
+
+  public void setLong(int parameterIndex, long x) throws SQLException {
+    realStatement.setLong(parameterIndex, x);
+  }
+
+  public void setFloat(int parameterIndex, float x) throws SQLException {
+    realStatement.setFloat(parameterIndex, x);
+  }
+
+  public void setDouble(int parameterIndex, double x) throws SQLException {
+    realStatement.setDouble(parameterIndex, x);
+  }
+
+  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+    realStatement.setBigDecimal(parameterIndex, x);
+  }
+
+  public void setString(int parameterIndex, String x) throws SQLException {
+    realStatement.setString(parameterIndex, x);
+  }
+
+  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+    realStatement.setBytes(parameterIndex, x);
+  }
+
+  public void setDate(int parameterIndex, Date x) throws SQLException {
+    realStatement.setDate(parameterIndex, x);
+  }
+
+  public void setTime(int parameterIndex, Time x) throws SQLException {
+    realStatement.setTime(parameterIndex, x);
+  }
+
+  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+    realStatement.setTimestamp(parameterIndex, x);
+  }
+
+  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    realStatement.setAsciiStream(parameterIndex, x, length);
+  }
+
+  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    realStatement.setUnicodeStream(parameterIndex, x, length);
+  }
+
+  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+    realStatement.setBinaryStream(parameterIndex, x, length);
+  }
+
+  public void clearParameters() throws SQLException {
+    realStatement.clearParameters();
+  }
+
+  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    realStatement.setObject(parameterIndex, x, targetSqlType);
+  }
+
+  public void setObject(int parameterIndex, Object x) throws SQLException {
+    realStatement.setObject(parameterIndex, x);
+  }
+
+  public boolean execute() throws SQLException {
+    return realStatement.execute();
+  }
+
+  public void addBatch() throws SQLException {
+    realStatement.addBatch();
+  }
+
+  public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
+    realStatement.setCharacterStream(parameterIndex, reader, length);
+  }
+
+  public void setRef(int parameterIndex, Ref x) throws SQLException {
+    realStatement.setRef(parameterIndex, x);
+  }
+
+  public void setBlob(int parameterIndex, Blob x) throws SQLException {
+    realStatement.setBlob(parameterIndex, x);
+  }
+
+  public void setClob(int parameterIndex, Clob x) throws SQLException {
+    realStatement.setClob(parameterIndex, x);
+  }
+
+  public void setArray(int parameterIndex, Array x) throws SQLException {
+    realStatement.setArray(parameterIndex, x);
+  }
+
+  public ResultSetMetaData getMetaData() throws SQLException {
+    return realStatement.getMetaData();
+  }
+
+  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+    realStatement.setDate(parameterIndex, x, cal);
+  }
+
+  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+    realStatement.setTime(parameterIndex, x, cal);
+  }
+
+  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+    realStatement.setTimestamp(parameterIndex, x, cal);
+  }
+
+  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+    realStatement.setNull(parameterIndex, sqlType, typeName);
+  }
+
+  public void setURL(int parameterIndex, URL x) throws SQLException {
+    realStatement.setURL(parameterIndex, x);
+  }
+
+  public ParameterMetaData getParameterMetaData() throws SQLException {
+    return realStatement.getParameterMetaData();
+  }
+
+  public void setRowId(int parameterIndex, RowId x) throws SQLException {
+    realStatement.setRowId(parameterIndex, x);
+  }
+
+  public void setNString(int parameterIndex, String value) throws SQLException {
+    realStatement.setNString(parameterIndex, value);
+  }
+
+  public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
+    realStatement.setNCharacterStream(parameterIndex, value, length);
+  }
+
+  public void setNClob(int parameterIndex, NClob value) throws SQLException {
+    realStatement.setNClob(parameterIndex, value);
+  }
+
+  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+    realStatement.setClob(parameterIndex, reader, length);
+  }
+
+  public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
+    realStatement.setBlob(parameterIndex, inputStream, length);
+  }
+
+  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+    realStatement.setNClob(parameterIndex, reader, length);
+  }
+
+  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+    realStatement.setSQLXML(parameterIndex, xmlObject);
+  }
+
+  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
+    realStatement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+  }
+
+  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+    realStatement.setAsciiStream(parameterIndex, x, length);
+  }
+
+  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+    realStatement.setBinaryStream(parameterIndex, x, length);
+  }
+
+  public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
+    realStatement.setCharacterStream(parameterIndex, reader, length);
+  }
+
+  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+    realStatement.setAsciiStream(parameterIndex, x);
+  }
+
+  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+    realStatement.setBinaryStream(parameterIndex, x);
+  }
+
+  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+    realStatement.setCharacterStream(parameterIndex, reader);
+  }
+
+  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+    realStatement.setNCharacterStream(parameterIndex, value);
+  }
+
+  public void setClob(int parameterIndex, Reader reader) throws SQLException {
+    realStatement.setClob(parameterIndex, reader);
+  }
+
+  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+    realStatement.setBlob(parameterIndex, inputStream);
+  }
+
+  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+    realStatement.setNClob(parameterIndex, reader);
+  }
+
+  public ResultSet executeQuery(String sql) throws SQLException {
+    return realStatement.executeQuery(sql);
+  }
+
+  public int executeUpdate(String sql) throws SQLException {
+    return realStatement.executeUpdate(sql);
+  }
+
+  public void close() throws SQLException {
+    realStatement.close();
+  }
+
+  public int getMaxFieldSize() throws SQLException {
+    return realStatement.getMaxFieldSize();
+  }
+
+  public void setMaxFieldSize(int max) throws SQLException {
+    realStatement.setMaxFieldSize(max);
+  }
+
+  public int getMaxRows() throws SQLException {
+    return realStatement.getMaxRows();
+  }
+
+  public void setMaxRows(int max) throws SQLException {
+    realStatement.setMaxRows(max);
+  }
+
+  public void setEscapeProcessing(boolean enable) throws SQLException {
+    realStatement.setEscapeProcessing(enable);
+  }
+
+  public int getQueryTimeout() throws SQLException {
+    return realStatement.getQueryTimeout();
+  }
+
+  public void setQueryTimeout(int seconds) throws SQLException {
+    realStatement.setQueryTimeout(seconds);
+  }
+
+  public void cancel() throws SQLException {
+    realStatement.cancel();
+  }
+
+  public SQLWarning getWarnings() throws SQLException {
+    return realStatement.getWarnings();
+  }
+
+  public void clearWarnings() throws SQLException {
+    realStatement.clearWarnings();
+  }
+
+  public void setCursorName(String name) throws SQLException {
+    realStatement.setCursorName(name);
+  }
+
+  public boolean execute(String sql) throws SQLException {
+    return realStatement.execute(sql);
+  }
+
+  public ResultSet getResultSet() throws SQLException {
+    return realStatement.getResultSet();
+  }
+
+  public int getUpdateCount() throws SQLException {
+    return realStatement.getUpdateCount();
+  }
+
+  public boolean getMoreResults() throws SQLException {
+    return realStatement.getMoreResults();
+  }
+
+  public void setFetchDirection(int direction) throws SQLException {
+    realStatement.setFetchDirection(direction);
+  }
+
+  public int getFetchDirection() throws SQLException {
+    return realStatement.getFetchDirection();
+  }
+
+  public void setFetchSize(int rows) throws SQLException {
+    realStatement.setFetchSize(rows);
+  }
+
+  public int getFetchSize() throws SQLException {
+    return realStatement.getFetchSize();
+  }
+
+  public int getResultSetConcurrency() throws SQLException {
+    return realStatement.getResultSetConcurrency();
+  }
+
+  public int getResultSetType() throws SQLException {
+    return realStatement.getResultSetType();
+  }
+
+  public void addBatch(String sql) throws SQLException {
+    realStatement.addBatch(sql);
+  }
+
+  public void clearBatch() throws SQLException {
+    realStatement.clearBatch();
+  }
+
+  public int[] executeBatch() throws SQLException {
+    return realStatement.executeBatch();
+  }
+
+  public Connection getConnection() throws SQLException {
+    return realStatement.getConnection();
+  }
+
+  public boolean getMoreResults(int current) throws SQLException {
+    return realStatement.getMoreResults(current);
+  }
+
+  public ResultSet getGeneratedKeys() throws SQLException {
+    return realStatement.getGeneratedKeys();
+  }
+
+  public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+    return realStatement.executeUpdate(sql, autoGeneratedKeys);
+  }
+
+  public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+    return realStatement.executeUpdate(sql, columnIndexes);
+  }
+
+  public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+    return realStatement.executeUpdate(sql, columnNames);
+  }
+
+  public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+    return realStatement.execute(sql, autoGeneratedKeys);
+  }
+
+  public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+    return realStatement.execute(sql, columnIndexes);
+  }
+
+  public boolean execute(String sql, String[] columnNames) throws SQLException {
+    return realStatement.execute(sql, columnNames);
+  }
+
+  public int getResultSetHoldability() throws SQLException {
+    return realStatement.getResultSetHoldability();
+  }
+
+  public boolean isClosed() throws SQLException {
+    return realStatement.isClosed();
+  }
+
+  public void setPoolable(boolean poolable) throws SQLException {
+    realStatement.setPoolable(poolable);
+  }
+
+  public boolean isPoolable() throws SQLException {
+    return realStatement.isPoolable();
+  }
+
+  public void closeOnCompletion() throws SQLException {
+    realStatement.closeOnCompletion();
+  }
+
+  public boolean isCloseOnCompletion() throws SQLException {
+    return realStatement.isCloseOnCompletion();
+  }
+
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return realStatement.unwrap(iface);
+  }
+
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return realStatement.isWrapperFor(iface);
+  }
+}

--- a/src/main/java/org/teiid/translator/adabas/ConnxCallableStatementWrapper.java
+++ b/src/main/java/org/teiid/translator/adabas/ConnxCallableStatementWrapper.java
@@ -16,36 +16,34 @@ public class ConnxCallableStatementWrapper implements CallableStatement {
     this.realStatement = realStatement;
   }
 
-  //TODO use the calendar instance after delegating the method to implement the expected behaviour
-
   //CONNX does not support this method
   public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
-    return realStatement.getDate(parameterIndex);
-  }
-
-  //CONNX does not support this method
-  public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
-    return realStatement.getTime(parameterIndex);
-  }
-
-  //CONNX does not support this method
-  public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
-    return realStatement.getTimestamp(parameterIndex);
+    return CalendarHelper.adjustDate(cal, getDate(parameterIndex));
   }
 
   //CONNX does not support this method
   public Date getDate(String parameterName, Calendar cal) throws SQLException {
-    return realStatement.getDate(parameterName);
+    return CalendarHelper.adjustDate(cal, getDate(parameterName));
+  }
+
+  //CONNX does not support this method
+  public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
+    return CalendarHelper.adjustTime(cal, getTime(parameterIndex));
   }
 
   //CONNX does not support this method
   public Time getTime(String parameterName, Calendar cal) throws SQLException {
-    return realStatement.getTime(parameterName);
+    return CalendarHelper.adjustTime(cal, getTime(parameterName));
+  }
+
+  //CONNX does not support this method
+  public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
+    return CalendarHelper.adjustTimestamp(cal, getTimestamp(parameterIndex));
   }
 
   //CONNX does not support this method
   public Timestamp getTimestamp(String parameterName, Calendar cal) throws SQLException {
-    return realStatement.getTimestamp(parameterName);
+    return CalendarHelper.adjustTimestamp(cal, getTimestamp(parameterName));
   }
 
   public void registerOutParameter(int parameterIndex, int sqlType) throws SQLException {

--- a/src/main/java/org/teiid/translator/adabas/ConnxResultSetWrapper.java
+++ b/src/main/java/org/teiid/translator/adabas/ConnxResultSetWrapper.java
@@ -16,6 +16,36 @@ public class ConnxResultSetWrapper implements ResultSet {
     this.realResultSet = realResultSet;
   }
 
+  // CONNX does not support this method
+  public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    return realResultSet.getDate(columnIndex);
+  }
+
+  // CONNX does not support this method
+  public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    return realResultSet.getDate(columnLabel);
+  }
+
+  // CONNX does not support this method
+  public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    return realResultSet.getTime(columnIndex);
+  }
+
+  // CONNX does not support this method
+  public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    return realResultSet.getTime(columnLabel);
+  }
+
+  // CONNX does not support this method
+  public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    return realResultSet.getTimestamp(columnIndex);
+  }
+
+  // CONNX does not support this method
+  public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    return realResultSet.getTimestamp(columnLabel);
+  }
+
   public boolean next() throws SQLException {
     return realResultSet.next();
   }
@@ -506,36 +536,6 @@ public class ConnxResultSetWrapper implements ResultSet {
 
   public Array getArray(String columnLabel) throws SQLException {
     return realResultSet.getArray(columnLabel);
-  }
-
-  // CONNX does not support this method
-  public Date getDate(int columnIndex, Calendar cal) throws SQLException {
-    return realResultSet.getDate(columnIndex);
-  }
-
-  // CONNX does not support this method
-  public Date getDate(String columnLabel, Calendar cal) throws SQLException {
-    return realResultSet.getDate(columnLabel);
-  }
-
-  // CONNX does not support this method
-  public Time getTime(int columnIndex, Calendar cal) throws SQLException {
-    return realResultSet.getTime(columnIndex);
-  }
-
-  // CONNX does not support this method
-  public Time getTime(String columnLabel, Calendar cal) throws SQLException {
-    return realResultSet.getTime(columnLabel);
-  }
-
-  // CONNX does not support this method
-  public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-    return realResultSet.getTimestamp(columnIndex);
-  }
-
-  // CONNX does not support this method
-  public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
-    return realResultSet.getTimestamp(columnLabel);
   }
 
   public URL getURL(int columnIndex) throws SQLException {

--- a/src/main/java/org/teiid/translator/adabas/ConnxResultSetWrapper.java
+++ b/src/main/java/org/teiid/translator/adabas/ConnxResultSetWrapper.java
@@ -1,0 +1,788 @@
+package org.teiid.translator.adabas;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
+import java.util.Calendar;
+import java.util.Map;
+
+public class ConnxResultSetWrapper implements ResultSet {
+
+  private final ResultSet realResultSet;
+
+  public ConnxResultSetWrapper(ResultSet realResultSet) {
+    this.realResultSet = realResultSet;
+  }
+
+  public boolean next() throws SQLException {
+    return realResultSet.next();
+  }
+
+  public void close() throws SQLException {
+    realResultSet.close();
+  }
+
+  public boolean wasNull() throws SQLException {
+    return realResultSet.wasNull();
+  }
+
+  public String getString(int columnIndex) throws SQLException {
+    return realResultSet.getString(columnIndex);
+  }
+
+  public boolean getBoolean(int columnIndex) throws SQLException {
+    return realResultSet.getBoolean(columnIndex);
+  }
+
+  public byte getByte(int columnIndex) throws SQLException {
+    return realResultSet.getByte(columnIndex);
+  }
+
+  public short getShort(int columnIndex) throws SQLException {
+    return realResultSet.getShort(columnIndex);
+  }
+
+  public int getInt(int columnIndex) throws SQLException {
+    return realResultSet.getInt(columnIndex);
+  }
+
+  public long getLong(int columnIndex) throws SQLException {
+    return realResultSet.getLong(columnIndex);
+  }
+
+  public float getFloat(int columnIndex) throws SQLException {
+    return realResultSet.getFloat(columnIndex);
+  }
+
+  public double getDouble(int columnIndex) throws SQLException {
+    return realResultSet.getDouble(columnIndex);
+  }
+
+  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+    return realResultSet.getBigDecimal(columnIndex, scale);
+  }
+
+  public byte[] getBytes(int columnIndex) throws SQLException {
+    return realResultSet.getBytes(columnIndex);
+  }
+
+  public Date getDate(int columnIndex) throws SQLException {
+    return realResultSet.getDate(columnIndex);
+  }
+
+  public Time getTime(int columnIndex) throws SQLException {
+    return realResultSet.getTime(columnIndex);
+  }
+
+  public Timestamp getTimestamp(int columnIndex) throws SQLException {
+    return realResultSet.getTimestamp(columnIndex);
+  }
+
+  public InputStream getAsciiStream(int columnIndex) throws SQLException {
+    return realResultSet.getAsciiStream(columnIndex);
+  }
+
+  public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+    return realResultSet.getUnicodeStream(columnIndex);
+  }
+
+  public InputStream getBinaryStream(int columnIndex) throws SQLException {
+    return realResultSet.getBinaryStream(columnIndex);
+  }
+
+  public String getString(String columnLabel) throws SQLException {
+    return realResultSet.getString(columnLabel);
+  }
+
+  public boolean getBoolean(String columnLabel) throws SQLException {
+    return realResultSet.getBoolean(columnLabel);
+  }
+
+  public byte getByte(String columnLabel) throws SQLException {
+    return realResultSet.getByte(columnLabel);
+  }
+
+  public short getShort(String columnLabel) throws SQLException {
+    return realResultSet.getShort(columnLabel);
+  }
+
+  public int getInt(String columnLabel) throws SQLException {
+    return realResultSet.getInt(columnLabel);
+  }
+
+  public long getLong(String columnLabel) throws SQLException {
+    return realResultSet.getLong(columnLabel);
+  }
+
+  public float getFloat(String columnLabel) throws SQLException {
+    return realResultSet.getFloat(columnLabel);
+  }
+
+  public double getDouble(String columnLabel) throws SQLException {
+    return realResultSet.getDouble(columnLabel);
+  }
+
+  public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+    return realResultSet.getBigDecimal(columnLabel, scale);
+  }
+
+  public byte[] getBytes(String columnLabel) throws SQLException {
+    return realResultSet.getBytes(columnLabel);
+  }
+
+  public Date getDate(String columnLabel) throws SQLException {
+    return realResultSet.getDate(columnLabel);
+  }
+
+  public Time getTime(String columnLabel) throws SQLException {
+    return realResultSet.getTime(columnLabel);
+  }
+
+  public Timestamp getTimestamp(String columnLabel) throws SQLException {
+    return realResultSet.getTimestamp(columnLabel);
+  }
+
+  public InputStream getAsciiStream(String columnLabel) throws SQLException {
+    return realResultSet.getAsciiStream(columnLabel);
+  }
+
+  public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+    return realResultSet.getUnicodeStream(columnLabel);
+  }
+
+  public InputStream getBinaryStream(String columnLabel) throws SQLException {
+    return realResultSet.getBinaryStream(columnLabel);
+  }
+
+  public SQLWarning getWarnings() throws SQLException {
+    return realResultSet.getWarnings();
+  }
+
+  public void clearWarnings() throws SQLException {
+    realResultSet.clearWarnings();
+  }
+
+  public String getCursorName() throws SQLException {
+    return realResultSet.getCursorName();
+  }
+
+  public ResultSetMetaData getMetaData() throws SQLException {
+    return realResultSet.getMetaData();
+  }
+
+  public Object getObject(int columnIndex) throws SQLException {
+    return realResultSet.getObject(columnIndex);
+  }
+
+  public Object getObject(String columnLabel) throws SQLException {
+    return realResultSet.getObject(columnLabel);
+  }
+
+  public int findColumn(String columnLabel) throws SQLException {
+    return realResultSet.findColumn(columnLabel);
+  }
+
+  public Reader getCharacterStream(int columnIndex) throws SQLException {
+    return realResultSet.getCharacterStream(columnIndex);
+  }
+
+  public Reader getCharacterStream(String columnLabel) throws SQLException {
+    return realResultSet.getCharacterStream(columnLabel);
+  }
+
+  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+    return realResultSet.getBigDecimal(columnIndex);
+  }
+
+  public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+    return realResultSet.getBigDecimal(columnLabel);
+  }
+
+  public boolean isBeforeFirst() throws SQLException {
+    return realResultSet.isBeforeFirst();
+  }
+
+  public boolean isAfterLast() throws SQLException {
+    return realResultSet.isAfterLast();
+  }
+
+  public boolean isFirst() throws SQLException {
+    return realResultSet.isFirst();
+  }
+
+  public boolean isLast() throws SQLException {
+    return realResultSet.isLast();
+  }
+
+  public void beforeFirst() throws SQLException {
+    realResultSet.beforeFirst();
+  }
+
+  public void afterLast() throws SQLException {
+    realResultSet.afterLast();
+  }
+
+  public boolean first() throws SQLException {
+    return realResultSet.first();
+  }
+
+  public boolean last() throws SQLException {
+    return realResultSet.last();
+  }
+
+  public int getRow() throws SQLException {
+    return realResultSet.getRow();
+  }
+
+  public boolean absolute(int row) throws SQLException {
+    return realResultSet.absolute(row);
+  }
+
+  public boolean relative(int rows) throws SQLException {
+    return realResultSet.relative(rows);
+  }
+
+  public boolean previous() throws SQLException {
+    return realResultSet.previous();
+  }
+
+  public void setFetchDirection(int direction) throws SQLException {
+    realResultSet.setFetchDirection(direction);
+  }
+
+  public int getFetchDirection() throws SQLException {
+    return realResultSet.getFetchDirection();
+  }
+
+  public void setFetchSize(int rows) throws SQLException {
+    realResultSet.setFetchSize(rows);
+  }
+
+  public int getFetchSize() throws SQLException {
+    return realResultSet.getFetchSize();
+  }
+
+  public int getType() throws SQLException {
+    return realResultSet.getType();
+  }
+
+  public int getConcurrency() throws SQLException {
+    return realResultSet.getConcurrency();
+  }
+
+  public boolean rowUpdated() throws SQLException {
+    return realResultSet.rowUpdated();
+  }
+
+  public boolean rowInserted() throws SQLException {
+    return realResultSet.rowInserted();
+  }
+
+  public boolean rowDeleted() throws SQLException {
+    return realResultSet.rowDeleted();
+  }
+
+  public void updateNull(int columnIndex) throws SQLException {
+    realResultSet.updateNull(columnIndex);
+  }
+
+  public void updateBoolean(int columnIndex, boolean x) throws SQLException {
+    realResultSet.updateBoolean(columnIndex, x);
+  }
+
+  public void updateByte(int columnIndex, byte x) throws SQLException {
+    realResultSet.updateByte(columnIndex, x);
+  }
+
+  public void updateShort(int columnIndex, short x) throws SQLException {
+    realResultSet.updateShort(columnIndex, x);
+  }
+
+  public void updateInt(int columnIndex, int x) throws SQLException {
+    realResultSet.updateInt(columnIndex, x);
+  }
+
+  public void updateLong(int columnIndex, long x) throws SQLException {
+    realResultSet.updateLong(columnIndex, x);
+  }
+
+  public void updateFloat(int columnIndex, float x) throws SQLException {
+    realResultSet.updateFloat(columnIndex, x);
+  }
+
+  public void updateDouble(int columnIndex, double x) throws SQLException {
+    realResultSet.updateDouble(columnIndex, x);
+  }
+
+  public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+    realResultSet.updateBigDecimal(columnIndex, x);
+  }
+
+  public void updateString(int columnIndex, String x) throws SQLException {
+    realResultSet.updateString(columnIndex, x);
+  }
+
+  public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+    realResultSet.updateBytes(columnIndex, x);
+  }
+
+  public void updateDate(int columnIndex, Date x) throws SQLException {
+    realResultSet.updateDate(columnIndex, x);
+  }
+
+  public void updateTime(int columnIndex, Time x) throws SQLException {
+    realResultSet.updateTime(columnIndex, x);
+  }
+
+  public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+    realResultSet.updateTimestamp(columnIndex, x);
+  }
+
+  public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+    realResultSet.updateAsciiStream(columnIndex, x, length);
+  }
+
+  public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+    realResultSet.updateBinaryStream(columnIndex, x, length);
+  }
+
+  public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+    realResultSet.updateCharacterStream(columnIndex, x, length);
+  }
+
+  public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+    realResultSet.updateObject(columnIndex, x, scaleOrLength);
+  }
+
+  public void updateObject(int columnIndex, Object x) throws SQLException {
+    realResultSet.updateObject(columnIndex, x);
+  }
+
+  public void updateNull(String columnLabel) throws SQLException {
+    realResultSet.updateNull(columnLabel);
+  }
+
+  public void updateBoolean(String columnLabel, boolean x) throws SQLException {
+    realResultSet.updateBoolean(columnLabel, x);
+  }
+
+  public void updateByte(String columnLabel, byte x) throws SQLException {
+    realResultSet.updateByte(columnLabel, x);
+  }
+
+  public void updateShort(String columnLabel, short x) throws SQLException {
+    realResultSet.updateShort(columnLabel, x);
+  }
+
+  public void updateInt(String columnLabel, int x) throws SQLException {
+    realResultSet.updateInt(columnLabel, x);
+  }
+
+  public void updateLong(String columnLabel, long x) throws SQLException {
+    realResultSet.updateLong(columnLabel, x);
+  }
+
+  public void updateFloat(String columnLabel, float x) throws SQLException {
+    realResultSet.updateFloat(columnLabel, x);
+  }
+
+  public void updateDouble(String columnLabel, double x) throws SQLException {
+    realResultSet.updateDouble(columnLabel, x);
+  }
+
+  public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+    realResultSet.updateBigDecimal(columnLabel, x);
+  }
+
+  public void updateString(String columnLabel, String x) throws SQLException {
+    realResultSet.updateString(columnLabel, x);
+  }
+
+  public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+    realResultSet.updateBytes(columnLabel, x);
+  }
+
+  public void updateDate(String columnLabel, Date x) throws SQLException {
+    realResultSet.updateDate(columnLabel, x);
+  }
+
+  public void updateTime(String columnLabel, Time x) throws SQLException {
+    realResultSet.updateTime(columnLabel, x);
+  }
+
+  public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+    realResultSet.updateTimestamp(columnLabel, x);
+  }
+
+  public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
+    realResultSet.updateAsciiStream(columnLabel, x, length);
+  }
+
+  public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException {
+    realResultSet.updateBinaryStream(columnLabel, x, length);
+  }
+
+  public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException {
+    realResultSet.updateCharacterStream(columnLabel, reader, length);
+  }
+
+  public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+    realResultSet.updateObject(columnLabel, x, scaleOrLength);
+  }
+
+  public void updateObject(String columnLabel, Object x) throws SQLException {
+    realResultSet.updateObject(columnLabel, x);
+  }
+
+  public void insertRow() throws SQLException {
+    realResultSet.insertRow();
+  }
+
+  public void updateRow() throws SQLException {
+    realResultSet.updateRow();
+  }
+
+  public void deleteRow() throws SQLException {
+    realResultSet.deleteRow();
+  }
+
+  public void refreshRow() throws SQLException {
+    realResultSet.refreshRow();
+  }
+
+  public void cancelRowUpdates() throws SQLException {
+    realResultSet.cancelRowUpdates();
+  }
+
+  public void moveToInsertRow() throws SQLException {
+    realResultSet.moveToInsertRow();
+  }
+
+  public void moveToCurrentRow() throws SQLException {
+    realResultSet.moveToCurrentRow();
+  }
+
+  public Statement getStatement() throws SQLException {
+    return realResultSet.getStatement();
+  }
+
+  public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
+    return realResultSet.getObject(columnIndex, map);
+  }
+
+  public Ref getRef(int columnIndex) throws SQLException {
+    return realResultSet.getRef(columnIndex);
+  }
+
+  public Blob getBlob(int columnIndex) throws SQLException {
+    return realResultSet.getBlob(columnIndex);
+  }
+
+  public Clob getClob(int columnIndex) throws SQLException {
+    return realResultSet.getClob(columnIndex);
+  }
+
+  public Array getArray(int columnIndex) throws SQLException {
+    return realResultSet.getArray(columnIndex);
+  }
+
+  public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
+    return realResultSet.getObject(columnLabel, map);
+  }
+
+  public Ref getRef(String columnLabel) throws SQLException {
+    return realResultSet.getRef(columnLabel);
+  }
+
+  public Blob getBlob(String columnLabel) throws SQLException {
+    return realResultSet.getBlob(columnLabel);
+  }
+
+  public Clob getClob(String columnLabel) throws SQLException {
+    return realResultSet.getClob(columnLabel);
+  }
+
+  public Array getArray(String columnLabel) throws SQLException {
+    return realResultSet.getArray(columnLabel);
+  }
+
+  // CONNX does not support this method
+  public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    return realResultSet.getDate(columnIndex);
+  }
+
+  // CONNX does not support this method
+  public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    return realResultSet.getDate(columnLabel);
+  }
+
+  // CONNX does not support this method
+  public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    return realResultSet.getTime(columnIndex);
+  }
+
+  // CONNX does not support this method
+  public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    return realResultSet.getTime(columnLabel);
+  }
+
+  // CONNX does not support this method
+  public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    return realResultSet.getTimestamp(columnIndex);
+  }
+
+  // CONNX does not support this method
+  public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    return realResultSet.getTimestamp(columnLabel);
+  }
+
+  public URL getURL(int columnIndex) throws SQLException {
+    return realResultSet.getURL(columnIndex);
+  }
+
+  public URL getURL(String columnLabel) throws SQLException {
+    return realResultSet.getURL(columnLabel);
+  }
+
+  public void updateRef(int columnIndex, Ref x) throws SQLException {
+    realResultSet.updateRef(columnIndex, x);
+  }
+
+  public void updateRef(String columnLabel, Ref x) throws SQLException {
+    realResultSet.updateRef(columnLabel, x);
+  }
+
+  public void updateBlob(int columnIndex, Blob x) throws SQLException {
+    realResultSet.updateBlob(columnIndex, x);
+  }
+
+  public void updateBlob(String columnLabel, Blob x) throws SQLException {
+    realResultSet.updateBlob(columnLabel, x);
+  }
+
+  public void updateClob(int columnIndex, Clob x) throws SQLException {
+    realResultSet.updateClob(columnIndex, x);
+  }
+
+  public void updateClob(String columnLabel, Clob x) throws SQLException {
+    realResultSet.updateClob(columnLabel, x);
+  }
+
+  public void updateArray(int columnIndex, Array x) throws SQLException {
+    realResultSet.updateArray(columnIndex, x);
+  }
+
+  public void updateArray(String columnLabel, Array x) throws SQLException {
+    realResultSet.updateArray(columnLabel, x);
+  }
+
+  public RowId getRowId(int columnIndex) throws SQLException {
+    return realResultSet.getRowId(columnIndex);
+  }
+
+  public RowId getRowId(String columnLabel) throws SQLException {
+    return realResultSet.getRowId(columnLabel);
+  }
+
+  public void updateRowId(int columnIndex, RowId x) throws SQLException {
+    realResultSet.updateRowId(columnIndex, x);
+  }
+
+  public void updateRowId(String columnLabel, RowId x) throws SQLException {
+    realResultSet.updateRowId(columnLabel, x);
+  }
+
+  public int getHoldability() throws SQLException {
+    return realResultSet.getHoldability();
+  }
+
+  public boolean isClosed() throws SQLException {
+    return realResultSet.isClosed();
+  }
+
+  public void updateNString(int columnIndex, String nString) throws SQLException {
+    realResultSet.updateNString(columnIndex, nString);
+  }
+
+  public void updateNString(String columnLabel, String nString) throws SQLException {
+    realResultSet.updateNString(columnLabel, nString);
+  }
+
+  public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+    realResultSet.updateNClob(columnIndex, nClob);
+  }
+
+  public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+    realResultSet.updateNClob(columnLabel, nClob);
+  }
+
+  public NClob getNClob(int columnIndex) throws SQLException {
+    return realResultSet.getNClob(columnIndex);
+  }
+
+  public NClob getNClob(String columnLabel) throws SQLException {
+    return realResultSet.getNClob(columnLabel);
+  }
+
+  public SQLXML getSQLXML(int columnIndex) throws SQLException {
+    return realResultSet.getSQLXML(columnIndex);
+  }
+
+  public SQLXML getSQLXML(String columnLabel) throws SQLException {
+    return realResultSet.getSQLXML(columnLabel);
+  }
+
+  public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
+    realResultSet.updateSQLXML(columnIndex, xmlObject);
+  }
+
+  public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
+    realResultSet.updateSQLXML(columnLabel, xmlObject);
+  }
+
+  public String getNString(int columnIndex) throws SQLException {
+    return realResultSet.getNString(columnIndex);
+  }
+
+  public String getNString(String columnLabel) throws SQLException {
+    return realResultSet.getNString(columnLabel);
+  }
+
+  public Reader getNCharacterStream(int columnIndex) throws SQLException {
+    return realResultSet.getNCharacterStream(columnIndex);
+  }
+
+  public Reader getNCharacterStream(String columnLabel) throws SQLException {
+    return realResultSet.getNCharacterStream(columnLabel);
+  }
+
+  public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+    realResultSet.updateNCharacterStream(columnIndex, x, length);
+  }
+
+  public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+    realResultSet.updateNCharacterStream(columnLabel, reader, length);
+  }
+
+  public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
+    realResultSet.updateAsciiStream(columnIndex, x, length);
+  }
+
+  public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
+    realResultSet.updateBinaryStream(columnIndex, x, length);
+  }
+
+  public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+    realResultSet.updateCharacterStream(columnIndex, x, length);
+  }
+
+  public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException {
+    realResultSet.updateAsciiStream(columnLabel, x, length);
+  }
+
+  public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException {
+    realResultSet.updateBinaryStream(columnLabel, x, length);
+  }
+
+  public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+    realResultSet.updateCharacterStream(columnLabel, reader, length);
+  }
+
+  public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException {
+    realResultSet.updateBlob(columnIndex, inputStream, length);
+  }
+
+  public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException {
+    realResultSet.updateBlob(columnLabel, inputStream, length);
+  }
+
+  public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
+    realResultSet.updateClob(columnIndex, reader, length);
+  }
+
+  public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
+    realResultSet.updateClob(columnLabel, reader, length);
+  }
+
+  public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
+    realResultSet.updateNClob(columnIndex, reader, length);
+  }
+
+  public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
+    realResultSet.updateNClob(columnLabel, reader, length);
+  }
+
+  public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
+    realResultSet.updateNCharacterStream(columnIndex, x);
+  }
+
+  public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
+    realResultSet.updateNCharacterStream(columnLabel, reader);
+  }
+
+  public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
+    realResultSet.updateAsciiStream(columnIndex, x);
+  }
+
+  public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
+    realResultSet.updateBinaryStream(columnIndex, x);
+  }
+
+  public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
+    realResultSet.updateCharacterStream(columnIndex, x);
+  }
+
+  public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
+    realResultSet.updateAsciiStream(columnLabel, x);
+  }
+
+  public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
+    realResultSet.updateBinaryStream(columnLabel, x);
+  }
+
+  public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
+    realResultSet.updateCharacterStream(columnLabel, reader);
+  }
+
+  public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
+    realResultSet.updateBlob(columnIndex, inputStream);
+  }
+
+  public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
+    realResultSet.updateBlob(columnLabel, inputStream);
+  }
+
+  public void updateClob(int columnIndex, Reader reader) throws SQLException {
+    realResultSet.updateClob(columnIndex, reader);
+  }
+
+  public void updateClob(String columnLabel, Reader reader) throws SQLException {
+    realResultSet.updateClob(columnLabel, reader);
+  }
+
+  public void updateNClob(int columnIndex, Reader reader) throws SQLException {
+    realResultSet.updateNClob(columnIndex, reader);
+  }
+
+  public void updateNClob(String columnLabel, Reader reader) throws SQLException {
+    realResultSet.updateNClob(columnLabel, reader);
+  }
+
+  public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+    return realResultSet.getObject(columnIndex, type);
+  }
+
+  public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+    return realResultSet.getObject(columnLabel, type);
+  }
+
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return realResultSet.unwrap(iface);
+  }
+
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return realResultSet.isWrapperFor(iface);
+  }
+}

--- a/src/main/java/org/teiid/translator/adabas/ConnxResultSetWrapper.java
+++ b/src/main/java/org/teiid/translator/adabas/ConnxResultSetWrapper.java
@@ -16,6 +16,8 @@ public class ConnxResultSetWrapper implements ResultSet {
     this.realResultSet = realResultSet;
   }
 
+  //TODO use the calendar instance after delegating the method to implement the expected behaviour
+
   // CONNX does not support this method
   public Date getDate(int columnIndex, Calendar cal) throws SQLException {
     return realResultSet.getDate(columnIndex);

--- a/src/main/java/org/teiid/translator/adabas/ConnxResultSetWrapper.java
+++ b/src/main/java/org/teiid/translator/adabas/ConnxResultSetWrapper.java
@@ -16,36 +16,40 @@ public class ConnxResultSetWrapper implements ResultSet {
     this.realResultSet = realResultSet;
   }
 
-  //TODO use the calendar instance after delegating the method to implement the expected behaviour
-
   // CONNX does not support this method
   public Date getDate(int columnIndex, Calendar cal) throws SQLException {
-    return realResultSet.getDate(columnIndex);
+    Date value = getDate(columnIndex);
+    return CalendarHelper.adjustDate(cal, value);
   }
 
   // CONNX does not support this method
   public Date getDate(String columnLabel, Calendar cal) throws SQLException {
-    return realResultSet.getDate(columnLabel);
+    Date value = getDate(columnLabel);
+    return CalendarHelper.adjustDate(cal, value);
   }
 
   // CONNX does not support this method
   public Time getTime(int columnIndex, Calendar cal) throws SQLException {
-    return realResultSet.getTime(columnIndex);
+    Time value = getTime(columnIndex);
+    return CalendarHelper.adjustTime(cal, value);
   }
 
   // CONNX does not support this method
   public Time getTime(String columnLabel, Calendar cal) throws SQLException {
-    return realResultSet.getTime(columnLabel);
+    Time value = getTime(columnLabel);
+    return CalendarHelper.adjustTime(cal, value);
   }
 
   // CONNX does not support this method
   public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-    return realResultSet.getTimestamp(columnIndex);
+    Timestamp value = getTimestamp(columnIndex);
+    return CalendarHelper.adjustTimestamp(cal, value);
   }
 
   // CONNX does not support this method
   public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
-    return realResultSet.getTimestamp(columnLabel);
+    Timestamp value = getTimestamp(columnLabel);
+    return CalendarHelper.adjustTimestamp(cal, value);
   }
 
   public boolean next() throws SQLException {


### PR DESCRIPTION
This is a simple workaround for **get(`Date`|`Time`|`Timestamp`)** methods that receives a `Calendar`. CONNX JDBC Driver does not support this methods (it throws exceptions when called).

I've used a delegate to wrap the `ResulSet` and `CallableStatement` and modify the unsupported methods with a simple implementation. Currently, the workaround only discards the `Calendar` parameter and delegates to the _non-calendar_ versions (need to improve this later).

There are also other unsupported methods, but since they are all the setters, a workaround is not viable to do right now.
